### PR TITLE
Apply style footnote-container - add layout spacing

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -469,9 +469,6 @@ They are: notes, code blocks, lists */
 .blog-content .social-icons__list {
   margin: 0;
 }
-.blog-content aside {
-  margin: 20px 0 30px 0;
-}
 
 .blog-content__headline {
   grid-area: content-title;


### PR DESCRIPTION
[ISSUE #103] The footnotes were hugging the left of the screen because of overwriting styles